### PR TITLE
yocto-debian-12: add containerfile

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -16,6 +16,7 @@ If you have not pulled any of our container right now, you can run:
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-ubuntu-18.04 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-ubuntu-20.04 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-ubuntu-22.04 bash
+| podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-debian-12 bash
 |
 * an available container with a special tag:
 
@@ -23,6 +24,7 @@ If you have not pulled any of our container right now, you can run:
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-ubuntu-18.04:phy1 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-ubuntu-20.04:phy2 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-ubuntu-22.04:phy2 bash
+| podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-debian-12:phy1 bash
 |
 If you want to run a container with docker, only remove "--userns=keep-id":
 
@@ -36,6 +38,7 @@ You can also use the provided container files to build them locally:
 | podman build -t yocto-ubuntu-18.04:phy1 yocto-ubuntu-18.04/
 | podman build -t yocto-ubuntu-20.04:phy2 yocto-ubuntu-20.04/
 | podman build -t yocto-ubuntu-22.04:phy2 yocto-ubuntu-22.04/
+| podman build -t yocto-debian-12:phy1 yocto-debian-12/
 | podman build -t action-runner-ubuntu-22.04:phy2 action-runner-ubuntu-22.04/
 
 Run the local / already pulled container
@@ -44,6 +47,7 @@ Run the local / already pulled container
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it yocto-ubuntu-18.04:phy1 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it yocto-ubuntu-20.04:phy2 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it yocto-ubuntu-22.04:phy2 bash
+| podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it yocto-debian-12:phy1 bash
 
 Push local container to a registry
 ==================================
@@ -54,6 +58,8 @@ Push local container to a registry
 | pass=$(cat ~/sync/env/password_dockerhub_phybuilder);podman push --creds phybuilder:${pass} localhost/yocto-ubuntu-20.04:phy2 docker.io/phybuilder/yocto-ubuntu-20.04:phy2;unset pass
 | 
 | pass=$(cat ~/sync/env/password_dockerhub_phybuilder);podman push --creds phybuilder:${pass} localhost/yocto-ubuntu-22.04:phy2 docker.io/phybuilder/yocto-ubuntu-22.04:phy2;unset pass
+| 
+| pass=$(cat ~/sync/env/password_dockerhub_phybuilder);podman push --creds phybuilder:${pass} localhost/yocto-debian-12:phy1 docker.io/phybuilder/yocto-debian-12:phy1;unset pass
 |
 | pass=$(cat ~/sync/env/password_dockerhub_phybuilder);podman push --creds phybuilder:${pass} localhost/action-runner-ubuntu-22.04:phy2 docker.io/phybuilder/action-runner-ubuntu-22.04:phy2;unset pass
 

--- a/yocto-debian-12/Containerfile
+++ b/yocto-debian-12/Containerfile
@@ -1,0 +1,46 @@
+# debian 12 - bookworm
+FROM debian:bookworm-20230814
+
+RUN \
+    apt-get clean && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
+	build-essential \
+	chrpath \
+	cpio \
+	diffstat \
+	file \
+	g++-multilib \
+	gawk \
+	gcc-multilib \
+	git-core \
+	less \
+	libncurses-dev \
+	locales \
+	lz4 \
+	procps \
+	openssh-client \
+	python3 \
+	python3-distutils \
+	python3-pip \
+	socat \
+	sudo \
+	sysstat \
+	texinfo \
+	tmux \
+	unzip \
+	vim \
+	wget \
+	xz-utils \
+	zstd \
+    && rm -rf /var/lib/apt/lists/* && \
+    echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
+    locale-gen
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN \
+    wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
+    chmod a+x /usr/local/bin/phyLinux && \
+    wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
+    chmod a+x /usr/local/bin/repo


### PR DESCRIPTION
Add build container for latest debian 12 bookworm. Current BSP master
builds work using podman. There is still a compatibilty issue with
legacy docker setup.

Signed-off-by: Stefan Müller-Klieser <s.mueller-klieser@phytec.de>
