### PR TITLE
Container: add rsync to all build containers

### DIFF
--- a/yocto-debian-12/Containerfile
+++ b/yocto-debian-12/Containerfile
@@ -23,6 +23,7 @@ RUN \
 	python3 \
 	python3-distutils \
 	python3-pip \
+	rsync \
 	socat \
 	sudo \
 	sysstat \

--- a/yocto-ubuntu-18.04/Containerfile
+++ b/yocto-ubuntu-18.04/Containerfile
@@ -18,6 +18,7 @@ RUN \
         python \
         python3 \
         python3-distutils \
+	rsync \
         socat \
         sudo \
         texinfo \

--- a/yocto-ubuntu-20.04/Containerfile
+++ b/yocto-ubuntu-20.04/Containerfile
@@ -32,6 +32,7 @@ RUN \
 	python3-jinja2 \
 	python3-pexpect \
 	python3-pip \
+	rsync \
 	socat \
 	sudo \
 	texinfo \


### PR DESCRIPTION
Linux kernel main makefile calls rsync for header installation. We
should keep in all containers to cover the corresponding tasks.

Signed-off-by: Stefan Müller-Klieser <s.mueller-klieser@phytec.de>
