### PR TITLE
python-ubuntu-22.04: container with multiple python versions

### DIFF
--- a/python-ubuntu-22.04/Containerfile
+++ b/python-ubuntu-22.04/Containerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN \
+    apt-get update -y && \
+    apt-get install -y -q --no-install-recommends \
+	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+    build-essential \
+    curl \
+    git \
+    libbz2-dev \
+    libedit-dev \
+    libeditreadline-dev \
+    libffi-dev \
+    liblzma-dev \
+    libncurses5-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    lzma-dev \
+    make \
+    openssh-client \
+    tk-dev \
+    tox \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LANGUAGE='en_US:en'
+
+# Install ``pyenv``.
+ENV PYENV_ROOT "/root/.pyenv"
+RUN git clone https://github.com/pyenv/pyenv $PYENV_ROOT \
+    && cd $PYENV_ROOT \
+    && src/configure \
+    && make -C src
+
+ARG PYTHON_VERSIONS="3.8 3.9 3.10 3.11 3.12"
+
+ENV PATH "$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+# Install pyhon versions
+RUN echo "install python start" \
+    && pyenv install ${PYTHON_VERSIONS} \
+    && pyenv global `pyenv versions --bare` \
+    && pyenv rehash \


### PR DESCRIPTION
uses pyenv to install python versions

podman build -t python-ubuntu-22.04  python-ubuntu-22.04/

example to build doc:

podman run --rm=true -v /tmp:/tmp \
 -v $SSH_AUTH_SOCK:$SSH_AUTH_SOCK -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK \
 -v ~/.ssh/known_hosts:/root/.ssh/known_hosts --workdir=$PWD \
 -it python-ubuntu-22.04:latest tox -e py310-doc

mounts /tmp as current working dir
mounts ssh agent to access
mounts known_hosts for github keys