### PR TITLE
Fix Ubuntu 2x.04 images

### DIFF
--- a/yocto-ubuntu-20.04/Containerfile
+++ b/yocto-ubuntu-20.04/Containerfile
@@ -4,16 +4,20 @@ RUN \
     apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
 	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+	bc \
+	bison \
 	bsdmainutils \
 	build-essential \
 	chrpath \
 	cpio \
 	diffstat \
 	file \
+	flex \
 	g++-multilib \
 	gawk \
 	gcc-multilib \
 	git-core \
+	gnupg \
 	iputils-ping \
 	libegl1-mesa \
 	libgmp-dev \
@@ -42,7 +46,6 @@ RUN \
 	wget \
 	xterm \
 	zstd \
-	gnupg \
     && rm -rf /var/lib/apt/lists/* && \
     locale-gen en_US.UTF-8
 

--- a/yocto-ubuntu-22.04/Containerfile
+++ b/yocto-ubuntu-22.04/Containerfile
@@ -4,16 +4,20 @@ RUN \
     apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
 	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+	bc \
+	bison \
 	bsdmainutils \
 	build-essential \
 	chrpath \
 	cpio \
 	diffstat \
 	file \
+	flex \
 	g++-multilib \
 	gawk \
 	gcc-multilib \
 	git-core \
+	gnupg \
 	iputils-ping \
 	libegl1-mesa \
 	libgmp-dev \
@@ -42,7 +46,6 @@ RUN \
 	wget \
 	xterm \
 	zstd \
-	gnupg \
     && rm -rf /var/lib/apt/lists/* && \
     locale-gen en_US.UTF-8
 


### PR DESCRIPTION
Add packages to compile a standalone kernel inside a container. Additionally, add an Ubuntu 24.04 image.