### PR TITLE
Add yocto ubuntu 24.04

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -44,6 +44,7 @@ If you have not pulled any of our container right now, you can run:
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-ubuntu-18.04 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-ubuntu-20.04 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-ubuntu-22.04 bash
+| podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-ubuntu-24.04 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-debian-12 bash
 |
 * an available container with a special tag:
@@ -52,6 +53,7 @@ If you have not pulled any of our container right now, you can run:
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-ubuntu-18.04:phy1 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-ubuntu-20.04:phy2 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-ubuntu-22.04:phy2 bash
+| podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-ubuntu-24.04:phy1 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it docker.io/phybuilder/yocto-debian-12:phy1 bash
 |
 If you want to run a container with docker, only remove "--userns=keep-id":
@@ -66,6 +68,7 @@ You can also use the provided container files to build them locally:
 | podman build -t yocto-ubuntu-18.04:phy1 yocto-ubuntu-18.04/
 | podman build -t yocto-ubuntu-20.04:phy2 yocto-ubuntu-20.04/
 | podman build -t yocto-ubuntu-22.04:phy2 yocto-ubuntu-22.04/
+| podman build -t yocto-ubuntu-24.04:phy1 yocto-ubuntu-24.04/
 | podman build -t yocto-debian-12:phy1 yocto-debian-12/
 | podman build -t zephyr-ubuntu-22.04:phy1 zephyr-ubuntu-22.04/
 | podman build -t zephyr-0.16.y-ubuntu-22.04:phy1 zephyr-0.16.y-ubuntu-22.04/
@@ -77,6 +80,7 @@ Run the local / already pulled container
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it yocto-ubuntu-18.04:phy1 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it yocto-ubuntu-20.04:phy2 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it yocto-ubuntu-22.04:phy2 bash
+| podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it yocto-ubuntu-24.04:phy1 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it yocto-debian-12:phy1 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it zephyr-ubuntu-22.04:phy1 bash
 | podman run --rm=true -v /home:/home --userns=keep-id --workdir=$PWD -it zephyr-0.16.y-ubuntu-22.04:phy1 bash
@@ -90,6 +94,8 @@ Push local container to a registry
 | pass=$(cat ~/sync/env/password_dockerhub_phybuilder);podman push --creds phybuilder:${pass} localhost/yocto-ubuntu-20.04:phy2 docker.io/phybuilder/yocto-ubuntu-20.04:phy2;unset pass
 | 
 | pass=$(cat ~/sync/env/password_dockerhub_phybuilder);podman push --creds phybuilder:${pass} localhost/yocto-ubuntu-22.04:phy2 docker.io/phybuilder/yocto-ubuntu-22.04:phy2;unset pass
+| 
+| pass=$(cat ~/sync/env/password_dockerhub_phybuilder);podman push --creds phybuilder:${pass} localhost/yocto-ubuntu-22.04:phy2 docker.io/phybuilder/yocto-ubuntu-24.04:phy1;unset pass
 | 
 | pass=$(cat ~/sync/env/password_dockerhub_phybuilder);podman push --creds phybuilder:${pass} localhost/yocto-debian-12:phy1 docker.io/phybuilder/yocto-debian-12:phy1;unset pass
 |

--- a/yocto-ubuntu-20.04/Containerfile
+++ b/yocto-ubuntu-20.04/Containerfile
@@ -4,16 +4,20 @@ RUN \
     apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
 	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+	bc \
+	bison \
 	bsdmainutils \
 	build-essential \
 	chrpath \
 	cpio \
 	diffstat \
 	file \
+	flex \
 	g++-multilib \
 	gawk \
 	gcc-multilib \
 	git-core \
+	gnupg \
 	iputils-ping \
 	libegl1-mesa \
 	libgmp-dev \
@@ -42,7 +46,6 @@ RUN \
 	wget \
 	xterm \
 	zstd \
-	gnupg \
     && rm -rf /var/lib/apt/lists/* && \
     locale-gen en_US.UTF-8
 

--- a/yocto-ubuntu-22.04/Containerfile
+++ b/yocto-ubuntu-22.04/Containerfile
@@ -4,16 +4,20 @@ RUN \
     apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
 	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+	bc \
+	bison \
 	bsdmainutils \
 	build-essential \
 	chrpath \
 	cpio \
 	diffstat \
 	file \
+	flex \
 	g++-multilib \
 	gawk \
 	gcc-multilib \
 	git-core \
+	gnupg \
 	iputils-ping \
 	libegl1-mesa \
 	libgmp-dev \
@@ -42,7 +46,6 @@ RUN \
 	wget \
 	xterm \
 	zstd \
-	gnupg \
     && rm -rf /var/lib/apt/lists/* && \
     locale-gen en_US.UTF-8
 

--- a/yocto-ubuntu-24.04/Containerfile
+++ b/yocto-ubuntu-24.04/Containerfile
@@ -1,0 +1,61 @@
+FROM ubuntu:24.04
+
+RUN \
+    apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
+	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+	bc \
+	bison \
+	bsdmainutils \
+	build-essential \
+	chrpath \
+	cpio \
+	diffstat \
+	file \
+	flex \
+	g++-multilib \
+	gawk \
+	gcc-multilib \
+	git-core \
+	gnupg \
+	iputils-ping \
+	libegl1-mesa-dev \
+	libgmp-dev \
+	libmpc-dev \
+	libncurses-dev \
+	libsdl1.2-dev \
+	libssl-dev \
+	locales \
+	lz4 \
+	openssh-client \
+	pylint \
+	python3 \
+	python3-git \
+	python3-jinja2 \
+	python3-pexpect \
+	python3-pip \
+	python-is-python3 \
+	socat \
+	sudo \
+	texinfo \
+	tmux \
+	unzip \
+	vim \
+	wget \
+	xterm \
+	zstd \
+    && rm -rf /var/lib/apt/lists/* && \
+    locale-gen en_US.UTF-8
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN \
+    apt-get update && \
+    apt-get install -y -q --no-install-recommends \
+	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+	ca-certificates \
+    && rm -rf /var/lib/apt/lists/* && \
+    wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
+    chmod a+x /usr/local/bin/phyLinux && \
+    wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
+    chmod a+x /usr/local/bin/repo


### PR DESCRIPTION
New Yocto Ubuntu 24.04 image for Styhead+

It starts to build but currently our AM62x master is broken. I was not able to fully verify a BSP build. Since it's possible to build half way through, I think it's fine because we currently have no Styhead release planned.