### PR TITLE
Add zephyr-0.17.y-ubuntu-22.04 Container

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ podman build -t yocto-ubuntu-22.04:local_build_1 yocto-ubuntu-22.04/
 podman run --rm=true -v /home:/home --userns=keep-id --workdir="${PWD}" -it yocto-ubuntu-20.04 bash
 podman run --rm=true -v /home:/home --userns=keep-id --workdir="${PWD}" -it yocto-ubuntu-22.04:phy2 bash
 podman run --rm=true -v /home:/home --userns=keep-id --workdir="${PWD}" -it zephyr-ubuntu-22.04:phy1 bash
-podman run --rm=true -v /home:/home --userns=keep-id --workdir="${PWD}" -it zephyr-0.16.y-ubuntu-22.04:phy1 bash
+podman run --rm=true -v /home:/home --userns=keep-id --workdir="${PWD}" -it zephyr-0.17.y-ubuntu-22.04:phy1 bash
 ```
 
 ## Push release build container to a registry

--- a/zephyr-0.17.y-ubuntu-22.04/Containerfile
+++ b/zephyr-0.17.y-ubuntu-22.04/Containerfile
@@ -1,0 +1,52 @@
+FROM ubuntu:22.04
+
+RUN \
+	apt-get update && \
+	DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
+	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+	locales \
+	wget \
+	git \
+	cmake \
+	ninja-build \
+	gperf \
+	ccache \
+	dfu-util \
+	device-tree-compiler \
+	wget \
+	python3-dev \
+	python3-pip \
+	python3-setuptools \
+	python3-tk \
+	python3-wheel \
+	python3-venv \
+	xz-utils \
+	file \
+	make \
+	gcc \
+	gcc-multilib \
+	g++-multilib \
+	libsdl2-dev \
+	libmagic1 \
+	&& rm -rf /var/lib/apt/lists/* && \
+	locale-gen en_US.UTF-8
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN pip install west pyelftools pyocd
+
+ARG ZEPHYR_SDK_RELEASE=0.17.0
+ARG ZEPHYR_SDK_TOOLCHAIN=arm-zephyr-eabi.tar.xz
+
+RUN wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_RELEASE}/zephyr-sdk-${ZEPHYR_SDK_RELEASE}_linux-x86_64_minimal.tar.xz && \
+	wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_RELEASE}/sha256.sum | shasum --check --ignore-missing && \
+	tar xvf zephyr-sdk-${ZEPHYR_SDK_RELEASE}_linux-x86_64_minimal.tar.xz && \
+	rm zephyr-sdk-${ZEPHYR_SDK_RELEASE}_linux-x86_64_minimal.tar.xz
+
+RUN cd zephyr-sdk-${ZEPHYR_SDK_RELEASE} && \
+	wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_RELEASE}/toolchain_linux-x86_64_${ZEPHYR_SDK_TOOLCHAIN} && \
+	wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_RELEASE}/sha256.sum | shasum --check --ignore-missing && \
+	tar xvf toolchain_linux-x86_64_${ZEPHYR_SDK_TOOLCHAIN} && \
+	rm toolchain_linux-x86_64_${ZEPHYR_SDK_TOOLCHAIN}
+
+RUN cd zephyr-sdk-${ZEPHYR_SDK_RELEASE} && ./setup.sh -c


### PR DESCRIPTION
This container has the more recent 0.17.0 Zephyr SDK installed, which is used in the v4.1 release.