### PR TITLE
Add Containerfile to build Android

### DIFF
--- a/android-ubuntu-24.04/Containerfile
+++ b/android-ubuntu-24.04/Containerfile
@@ -1,0 +1,92 @@
+FROM ubuntu:24.04
+
+RUN \
+	apt-get update && \
+	DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		bc \
+		bison \
+		bsdmainutils \
+		build-essential \
+		chrpath \
+		cpio \
+		diffstat \
+		file \
+		flex \
+		g++-multilib \
+		gawk \
+		gcc-multilib \
+		git-core \
+		gnupg \
+		iputils-ping \
+		less \
+		libegl1-mesa-dev \
+		libgmp-dev \
+		libmpc-dev \
+		libncurses-dev \
+		libsdl1.2-dev \
+		libssl-dev \
+		locales \
+		lz4 \
+		openssh-client \
+		pylint \
+		python3 \
+		python3-git \
+		python3-jinja2 \
+		python3-pexpect \
+		python3-pip \
+		python-is-python3 \
+		socat \
+		sudo \
+		texinfo \
+		tmux \
+		unzip \
+		vim \
+		wget \
+		xterm \
+		zstd \
+	&& rm -rf /var/lib/apt/lists/* && \
+	locale-gen en_US.UTF-8
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN \
+	apt-get update && \
+	apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		ca-certificates \
+	&& rm -rf /var/lib/apt/lists/* && \
+	wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
+	chmod a+x /usr/local/bin/phyLinux && \
+	wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
+	chmod a+x /usr/local/bin/repo
+
+# Additional Android packages
+RUN \
+	apt-get update && \
+	DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		curl \
+		dwarves \
+		fontconfig \
+		git-core \
+		lib32z1-dev \
+		libc6-dev-i386 \
+		libelf-dev \
+		libgl1-mesa-dev \
+		libtinfo6 \
+		libx11-dev \
+		libxml2-utils \
+		rsync \
+		swig \
+		python3-dev \
+		x11proto-core-dev \
+		xsltproc \
+		zip \
+		zlib1g-dev \
+	&& rm -rf /var/lib/apt/lists/* && \
+	locale-gen en_US.UTF-8
+
+# Android requires libncurses5 and libtinfo5 but Ubuntu doesn't provide them anymore
+RUN ln -s /usr/lib/x86_64-linux-gnu/libncurses.so.6 /usr/lib/x86_64-linux-gnu/libncurses.so.5
+RUN ln -s /usr/lib/x86_64-linux-gnu/libtinfo.so.6 /usr/lib/x86_64-linux-gnu/libtinfo.so.5

--- a/python-ubuntu-22.04/Containerfile
+++ b/python-ubuntu-22.04/Containerfile
@@ -2,41 +2,41 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN \
-    apt-get update -y && \
-    apt-get install -y -q --no-install-recommends \
-	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-    build-essential \
-    curl \
-    git \
-    libbz2-dev \
-    libedit-dev \
-    libeditreadline-dev \
-    libffi-dev \
-    liblzma-dev \
-    libncurses5-dev \
-    libsqlite3-dev \
-    libssl-dev \
-    lzma-dev \
-    make \
-    openssh-client \
-    tk-dev \
-    tox \
-    && rm -rf /var/lib/apt/lists/*
+	apt-get update -y && \
+	apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		build-essential \
+		curl \
+		git \
+		libbz2-dev \
+		libedit-dev \
+		libeditreadline-dev \
+		libffi-dev \
+		liblzma-dev \
+		libncurses5-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		lzma-dev \
+		make \
+		openssh-client \
+		tk-dev \
+		tox \
+	&& rm -rf /var/lib/apt/lists/*
 
 ENV LANGUAGE='en_US:en'
 
 # Install ``pyenv``.
 ENV PYENV_ROOT "/root/.pyenv"
 RUN git clone https://github.com/pyenv/pyenv $PYENV_ROOT \
-    && cd $PYENV_ROOT \
-    && src/configure \
-    && make -C src
+	&& cd $PYENV_ROOT \
+	&& src/configure \
+	&& make -C src
 
 ARG PYTHON_VERSIONS="3.8 3.9 3.10 3.11 3.12"
 
 ENV PATH "$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
 # Install pyhon versions
 RUN echo "install python start" \
-    && pyenv install ${PYTHON_VERSIONS} \
-    && pyenv global `pyenv versions --bare` \
-    && pyenv rehash \
+	&& pyenv install ${PYTHON_VERSIONS} \
+	&& pyenv global `pyenv versions --bare` \
+	&& pyenv rehash \

--- a/yocto-debian-12/Containerfile
+++ b/yocto-debian-12/Containerfile
@@ -2,9 +2,9 @@
 FROM debian:bookworm-20230814
 
 RUN \
-    apt-get clean && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
+	apt-get clean && \
+	apt-get update && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
 	build-essential \
 	chrpath \
 	cpio \
@@ -35,14 +35,14 @@ RUN \
 	wget \
 	xz-utils \
 	zstd \
-    && rm -rf /var/lib/apt/lists/* && \
-    echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
-    locale-gen
+	&& rm -rf /var/lib/apt/lists/* && \
+	echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
+	locale-gen
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN \
-    wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
-    chmod a+x /usr/local/bin/phyLinux && \
-    wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
-    chmod a+x /usr/local/bin/repo
+	wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
+	chmod a+x /usr/local/bin/phyLinux && \
+	wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
+	chmod a+x /usr/local/bin/repo

--- a/yocto-ubuntu-16.04/Containerfile
+++ b/yocto-ubuntu-16.04/Containerfile
@@ -1,42 +1,42 @@
 FROM ubuntu:16.04
 
 RUN \
-    apt-get update && \
-    apt-get install -y -q --no-install-recommends \
-        -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-        build-essential \
-        chrpath \
-        cpio \
-        diffstat \
-        file \
-        g++-multilib \
-        gawk \
-        gcc-multilib \
-        git-core \
-        locales \
-        openssh-client \
-        python \
-        python3 \
-        rsync \
-        socat \
-        sudo \
-        texinfo \
-        tmux \
-        unzip \
-        vim \
-        wget \
-    && rm -rf /var/lib/apt/lists/* && \
-    locale-gen en_US.UTF-8
+	apt-get update && \
+	apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		build-essential \
+		chrpath \
+		cpio \
+		diffstat \
+		file \
+		g++-multilib \
+		gawk \
+		gcc-multilib \
+		git-core \
+		locales \
+		openssh-client \
+		python \
+		python3 \
+		rsync \
+		socat \
+		sudo \
+		texinfo \
+		tmux \
+		unzip \
+		vim \
+		wget \
+	&& rm -rf /var/lib/apt/lists/* && \
+	locale-gen en_US.UTF-8
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN \
-    apt-get update && \
-    apt-get install -y -q --no-install-recommends \
-        -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-        ca-certificates \
-    && rm -rf /var/lib/apt/lists/* && \
-    wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
-    chmod a+x /usr/local/bin/phyLinux && \
-    wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
-    chmod a+x /usr/local/bin/repo
+	apt-get update && \
+	apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		ca-certificates \
+	&& rm -rf /var/lib/apt/lists/* && \
+	wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
+	chmod a+x /usr/local/bin/phyLinux && \
+	wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
+	chmod a+x /usr/local/bin/repo

--- a/yocto-ubuntu-18.04/Containerfile
+++ b/yocto-ubuntu-18.04/Containerfile
@@ -1,43 +1,43 @@
 FROM ubuntu:18.04
 
 RUN \
-    apt-get update && \
-    apt-get install -y -q --no-install-recommends \
-        -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-        build-essential \
-        chrpath \
-        cpio \
-        diffstat \
-        file \
-        g++-multilib \
-        gawk \
-        gcc-multilib \
-        git-core \
-        locales \
-        openssh-client \
-        python \
-        python3 \
-        python3-distutils \
-	rsync \
-        socat \
-        sudo \
-        texinfo \
-        tmux \
-        unzip \
-        vim \
-        wget \
-    && rm -rf /var/lib/apt/lists/* && \
-    locale-gen en_US.UTF-8
+	apt-get update && \
+	apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		build-essential \
+		chrpath \
+		cpio \
+		diffstat \
+		file \
+		g++-multilib \
+		gawk \
+		gcc-multilib \
+		git-core \
+		locales \
+		openssh-client \
+		python \
+		python3 \
+		python3-distutils \
+		rsync \
+		socat \
+		sudo \
+		texinfo \
+		tmux \
+		unzip \
+		vim \
+		wget \
+	&& rm -rf /var/lib/apt/lists/* && \
+	locale-gen en_US.UTF-8
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN \
-    apt-get update && \
-    apt-get install -y -q --no-install-recommends \
-        -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-        ca-certificates \
-    && rm -rf /var/lib/apt/lists/* && \
-    wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
-    chmod a+x /usr/local/bin/phyLinux && \
-    wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
-    chmod a+x /usr/local/bin/repo
+	apt-get update && \
+	apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		ca-certificates \
+	&& rm -rf /var/lib/apt/lists/* && \
+	wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
+	chmod a+x /usr/local/bin/phyLinux && \
+	wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
+	chmod a+x /usr/local/bin/repo

--- a/yocto-ubuntu-20.04/Containerfile
+++ b/yocto-ubuntu-20.04/Containerfile
@@ -1,64 +1,64 @@
 FROM ubuntu:20.04
 
 RUN \
-    apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
-	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-	bc \
-	bison \
-	bsdmainutils \
-	build-essential \
-	chrpath \
-	cpio \
-	diffstat \
-	file \
-	flex \
-	g++-multilib \
-	gawk \
-	gcc-multilib \
-	git-core \
-	gnupg \
-	iputils-ping \
-	less \
-	libegl1-mesa \
-	libgmp-dev \
-	libmpc-dev \
-	libncurses-dev \
-	libsdl1.2-dev \
-	libssl-dev \
-	locales \
-	lz4 \
-	openssh-client \
-	pylint \
-	python \
-	python3 \
-	python3-distutils \
-	python3-git \
-	python3-jinja2 \
-	python3-pexpect \
-	python3-pip \
-	rsync \
-	socat \
-	sudo \
-	texinfo \
-	tmux \
-	unzip \
-	vim \
-	wget \
-	xterm \
-	zstd \
-    && rm -rf /var/lib/apt/lists/* && \
-    locale-gen en_US.UTF-8
+	apt-get update && \
+	DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		bc \
+		bison \
+		bsdmainutils \
+		build-essential \
+		chrpath \
+		cpio \
+		diffstat \
+		file \
+		flex \
+		g++-multilib \
+		gawk \
+		gcc-multilib \
+		git-core \
+		gnupg \
+		iputils-ping \
+		less \
+		libegl1-mesa \
+		libgmp-dev \
+		libmpc-dev \
+		libncurses-dev \
+		libsdl1.2-dev \
+		libssl-dev \
+		locales \
+		lz4 \
+		openssh-client \
+		pylint \
+		python \
+		python3 \
+		python3-distutils \
+		python3-git \
+		python3-jinja2 \
+		python3-pexpect \
+		python3-pip \
+		rsync \
+		socat \
+		sudo \
+		texinfo \
+		tmux \
+		unzip \
+		vim \
+		wget \
+		xterm \
+		zstd \
+	&& rm -rf /var/lib/apt/lists/* && \
+	locale-gen en_US.UTF-8
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN \
-    apt-get update && \
-    apt-get install -y -q --no-install-recommends \
-	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-	ca-certificates \
-    && rm -rf /var/lib/apt/lists/* && \
-    wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
-    chmod a+x /usr/local/bin/phyLinux && \
-    wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
-    chmod a+x /usr/local/bin/repo
+	apt-get update && \
+	apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		ca-certificates \
+	&& rm -rf /var/lib/apt/lists/* && \
+	wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
+	chmod a+x /usr/local/bin/phyLinux && \
+	wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
+	chmod a+x /usr/local/bin/repo

--- a/yocto-ubuntu-22.04/Containerfile
+++ b/yocto-ubuntu-22.04/Containerfile
@@ -1,64 +1,64 @@
 FROM ubuntu:22.04
 
 RUN \
-    apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
-	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-	bc \
-	bison \
-	bsdmainutils \
-	build-essential \
-	chrpath \
-	cpio \
-	diffstat \
-	file \
-	flex \
-	g++-multilib \
-	gawk \
-	gcc-multilib \
-	git-core \
-	gnupg \
-	iputils-ping \
-	less \
-	libegl1-mesa \
-	libgmp-dev \
-	libmpc-dev \
-	libncurses-dev \
-	libsdl1.2-dev \
-	libssl-dev \
-	locales \
-	lz4 \
-	openssh-client \
-	pylint \
-	python2 \
-	python3 \
-	python3-distutils \
-	python3-git \
-	python3-jinja2 \
-	python3-pexpect \
-	python3-pip \
-	python-is-python3 \
-	socat \
-	sudo \
-	texinfo \
-	tmux \
-	unzip \
-	vim \
-	wget \
-	xterm \
-	zstd \
-    && rm -rf /var/lib/apt/lists/* && \
-    locale-gen en_US.UTF-8
+	apt-get update && \
+	DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		bc \
+		bison \
+		bsdmainutils \
+		build-essential \
+		chrpath \
+		cpio \
+		diffstat \
+		file \
+		flex \
+		g++-multilib \
+		gawk \
+		gcc-multilib \
+		git-core \
+		gnupg \
+		iputils-ping \
+		less \
+		libegl1-mesa \
+		libgmp-dev \
+		libmpc-dev \
+		libncurses-dev \
+		libsdl1.2-dev \
+		libssl-dev \
+		locales \
+		lz4 \
+		openssh-client \
+		pylint \
+		python2 \
+		python3 \
+		python3-distutils \
+		python3-git \
+		python3-jinja2 \
+		python3-pexpect \
+		python3-pip \
+		python-is-python3 \
+		socat \
+		sudo \
+		texinfo \
+		tmux \
+		unzip \
+		vim \
+		wget \
+		xterm \
+		zstd \
+	&& rm -rf /var/lib/apt/lists/* && \
+	locale-gen en_US.UTF-8
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN \
-    apt-get update && \
-    apt-get install -y -q --no-install-recommends \
-	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-	ca-certificates \
-    && rm -rf /var/lib/apt/lists/* && \
-    wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
-    chmod a+x /usr/local/bin/phyLinux && \
-    wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
-    chmod a+x /usr/local/bin/repo
+	apt-get update && \
+	apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		ca-certificates \
+	&& rm -rf /var/lib/apt/lists/* && \
+	wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
+	chmod a+x /usr/local/bin/phyLinux && \
+	wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
+	chmod a+x /usr/local/bin/repo

--- a/yocto-ubuntu-24.04/Containerfile
+++ b/yocto-ubuntu-24.04/Containerfile
@@ -1,62 +1,62 @@
 FROM ubuntu:24.04
 
 RUN \
-    apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
-	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-	bc \
-	bison \
-	bsdmainutils \
-	build-essential \
-	chrpath \
-	cpio \
-	diffstat \
-	file \
-	flex \
-	g++-multilib \
-	gawk \
-	gcc-multilib \
-	git-core \
-	gnupg \
-	iputils-ping \
-	less \
-	libegl1-mesa-dev \
-	libgmp-dev \
-	libmpc-dev \
-	libncurses-dev \
-	libsdl1.2-dev \
-	libssl-dev \
-	locales \
-	lz4 \
-	openssh-client \
-	pylint \
-	python3 \
-	python3-git \
-	python3-jinja2 \
-	python3-pexpect \
-	python3-pip \
-	python-is-python3 \
-	socat \
-	sudo \
-	texinfo \
-	tmux \
-	unzip \
-	vim \
-	wget \
-	xterm \
-	zstd \
-    && rm -rf /var/lib/apt/lists/* && \
-    locale-gen en_US.UTF-8
+	apt-get update && \
+	DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		bc \
+		bison \
+		bsdmainutils \
+		build-essential \
+		chrpath \
+		cpio \
+		diffstat \
+		file \
+		flex \
+		g++-multilib \
+		gawk \
+		gcc-multilib \
+		git-core \
+		gnupg \
+		iputils-ping \
+		less \
+		libegl1-mesa-dev \
+		libgmp-dev \
+		libmpc-dev \
+		libncurses-dev \
+		libsdl1.2-dev \
+		libssl-dev \
+		locales \
+		lz4 \
+		openssh-client \
+		pylint \
+		python3 \
+		python3-git \
+		python3-jinja2 \
+		python3-pexpect \
+		python3-pip \
+		python-is-python3 \
+		socat \
+		sudo \
+		texinfo \
+		tmux \
+		unzip \
+		vim \
+		wget \
+		xterm \
+		zstd \
+	&& rm -rf /var/lib/apt/lists/* && \
+	locale-gen en_US.UTF-8
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN \
-    apt-get update && \
-    apt-get install -y -q --no-install-recommends \
-	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-	ca-certificates \
-    && rm -rf /var/lib/apt/lists/* && \
-    wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
-    chmod a+x /usr/local/bin/phyLinux && \
-    wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
-    chmod a+x /usr/local/bin/repo
+	apt-get update && \
+	apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		ca-certificates \
+	&& rm -rf /var/lib/apt/lists/* && \
+	wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
+	chmod a+x /usr/local/bin/phyLinux && \
+	wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
+	chmod a+x /usr/local/bin/repo

--- a/zephyr-0.16.y-ubuntu-22.04/Containerfile
+++ b/zephyr-0.16.y-ubuntu-22.04/Containerfile
@@ -1,41 +1,40 @@
 FROM ubuntu:22.04
 
 RUN \
-    apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
-	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-	locales \
-	wget \
-	git \
-	cmake \
-	ninja-build \
-	gperf \
-	ccache \
-	dfu-util \
-	device-tree-compiler \
-	wget \
-	python3-dev \
-	python3-pip \
-	python3-setuptools \
-	python3-tk \
-	python3-wheel \
-	python3-venv \
-	xz-utils \
-	file \
-	make \
-	gcc \
-	gcc-multilib \
-	g++-multilib \
-	libsdl2-dev \
-	libmagic1 \
-    && rm -rf /var/lib/apt/lists/* && \
-    locale-gen en_US.UTF-8
+	apt-get update && \
+	DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		locales \
+		wget \
+		git \
+		cmake \
+		ninja-build \
+		gperf \
+		ccache \
+		dfu-util \
+		device-tree-compiler \
+		wget \
+		python3-dev \
+		python3-pip \
+		python3-setuptools \
+		python3-tk \
+		python3-wheel \
+		python3-venv \
+		xz-utils \
+		file \
+		make \
+		gcc \
+		gcc-multilib \
+		g++-multilib \
+		libsdl2-dev \
+		libmagic1 \
+	&& rm -rf /var/lib/apt/lists/* && \
+	locale-gen en_US.UTF-8
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.6/zephyr-sdk-0.16.6_linux-x86_64.tar.xz && wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.6/sha256.sum | shasum --check --ignore-missing
 RUN tar xvf zephyr-sdk-0.16.6_linux-x86_64.tar.xz
 RUN rm zephyr-sdk-0.16.6_linux-x86_64.tar.xz
-
 
 RUN cd zephyr-sdk-0.16.6 && ./setup.sh -c

--- a/zephyr-ubuntu-22.04/Containerfile
+++ b/zephyr-ubuntu-22.04/Containerfile
@@ -1,34 +1,34 @@
 FROM ubuntu:22.04
 
 RUN \
-    apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
-	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-	locales \
-	wget \
-	git \
-	cmake \
-	ninja-build \
-	gperf \
-	ccache \
-	dfu-util \
-	device-tree-compiler \
-	wget \
-	python3-dev \
-	python3-pip \
-	python3-setuptools \
-	python3-tk \
-	python3-wheel \
-	python3-venv \
-	xz-utils \
-	file \
-	make \
-	gcc \
-	gcc-multilib \
-	g++-multilib \
-	libsdl2-dev \
-	libmagic1 \
-    && rm -rf /var/lib/apt/lists/* && \
-    locale-gen en_US.UTF-8
+	apt-get update && \
+	DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
+		-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+		locales \
+		wget \
+		git \
+		cmake \
+		ninja-build \
+		gperf \
+		ccache \
+		dfu-util \
+		device-tree-compiler \
+		wget \
+		python3-dev \
+		python3-pip \
+		python3-setuptools \
+		python3-tk \
+		python3-wheel \
+		python3-venv \
+		xz-utils \
+		file \
+		make \
+		gcc \
+		gcc-multilib \
+		g++-multilib \
+		libsdl2-dev \
+		libmagic1 \
+	&& rm -rf /var/lib/apt/lists/* && \
+	locale-gen en_US.UTF-8
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'


### PR DESCRIPTION
This container is a copy of the ``yocto-ubuntu-24.04`` file with additional changes required by Android. I think it's easier to maintain this container in the future by just using the original yocto-ubuntu file and adding everything add the end.

This PR also includes some clean-ups with spaces/tabs.