### PR TITLE
Fix installation of kas for multi user system

### DIFF
--- a/yocto-debian-12/Containerfile
+++ b/yocto-debian-12/Containerfile
@@ -48,4 +48,4 @@ RUN \
     wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
     chmod a+x /usr/local/bin/repo
 
-RUN PIPX_BIN_DIR=/usr/local/bin pipx install kas==5.0
+RUN PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man pipx install kas==5.0

--- a/yocto-debian-13/Containerfile
+++ b/yocto-debian-13/Containerfile
@@ -48,4 +48,4 @@ RUN \
     wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
     chmod a+x /usr/local/bin/repo
 
-RUN PIPX_BIN_DIR=/usr/local/bin pipx install kas==5.0
+RUN pipx install --global kas==5.0

--- a/yocto-ubuntu-22.04/Containerfile
+++ b/yocto-ubuntu-22.04/Containerfile
@@ -64,4 +64,4 @@ RUN \
     wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
     chmod a+x /usr/local/bin/repo
 
-RUN PIPX_BIN_DIR=/usr/local/bin pipx install kas==5.0
+RUN PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man pipx install kas==5.0

--- a/yocto-ubuntu-24.04/Containerfile
+++ b/yocto-ubuntu-24.04/Containerfile
@@ -62,4 +62,4 @@ RUN \
     wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
     chmod a+x /usr/local/bin/repo
 
-RUN PIPX_BIN_DIR=/usr/local/bin pipx install kas==5.0
+RUN PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man pipx install kas==5.0


### PR DESCRIPTION
kas needs to be installed with PIPX_HOME pointing to a shared directory, so other users than root can access it. pipx 1.5.0 allows doing this via the --global flag, which is unavailable in previous versions and needs a workaround there. Still, the resulting installation is the same and files are placed in /opt/pipx, available for all users.