### PR TITLE
yocto-ubuntu-{22,24}.04: Add bash-completion

### DIFF
--- a/yocto-ubuntu-22.04/Containerfile
+++ b/yocto-ubuntu-22.04/Containerfile
@@ -4,6 +4,7 @@ RUN \
     apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
 	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+	bash-completion \
 	bc \
 	bison \
 	bsdmainutils \

--- a/yocto-ubuntu-24.04/Containerfile
+++ b/yocto-ubuntu-24.04/Containerfile
@@ -4,6 +4,7 @@ RUN \
     apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
 	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+	bash-completion \
 	bc \
 	bison \
 	bsdmainutils \


### PR DESCRIPTION
As the interactive usage of (at least those two) increases on our buildserver, it eases the usage of tools etc when bash-completion is available.