### PR TITLE
Add container based on Ubuntu 26.04

### DIFF
--- a/yocto-ubuntu-24.04/Containerfile
+++ b/yocto-ubuntu-24.04/Containerfile
@@ -9,6 +9,7 @@ RUN \
 	bison \
 	bsdmainutils \
 	build-essential \
+	ca-certificates \
 	chrpath \
 	cpio \
 	diffstat \
@@ -53,11 +54,6 @@ RUN \
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN \
-    apt-get update && \
-    apt-get install -y -q --no-install-recommends \
-	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-	ca-certificates \
-    && rm -rf /var/lib/apt/lists/* && \
     wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
     chmod a+x /usr/local/bin/phyLinux && \
     wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \

--- a/yocto-ubuntu-26.04/Containerfile
+++ b/yocto-ubuntu-26.04/Containerfile
@@ -1,0 +1,67 @@
+FROM ubuntu:26.04
+
+RUN \
+    apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install -y -q --no-install-recommends \
+	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+	bash-completion \
+	bc \
+	bison \
+	bsdmainutils \
+	build-essential \
+	ca-certificates \
+	chrpath \
+	cpio \
+	diffstat \
+	file \
+	flex \
+	g++-multilib \
+	gawk \
+	gcc-multilib \
+	git-core \
+	gnupg \
+	iputils-ping \
+	less \
+	libacl1 \
+	libcrypt-dev \
+	libegl1-mesa-dev \
+	libgmp-dev \
+	libmpc-dev \
+	libncurses-dev \
+	libsdl1.2-dev \
+	libssl-dev \
+	locales \
+	lz4 \
+	openssh-client \
+	pipx \
+	pylint \
+	python3 \
+	python3-git \
+	python3-jinja2 \
+	python3-pexpect \
+	python3-pip \
+	python3-subunit \
+	python3-websockets \
+	python-is-python3 \
+	socat \
+	sudo \
+	texinfo \
+	tmux \
+	unzip \
+	vim \
+	wget \
+	xterm \
+	xz-utils \
+	zstd \
+    && rm -rf /var/lib/apt/lists/* && \
+    locale-gen en_US.UTF-8
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN \
+    wget -O /usr/local/bin/phyLinux https://download.phytec.de/Software/Linux/Yocto/Tools/phyLinux && \
+    chmod a+x /usr/local/bin/phyLinux && \
+    wget -O /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo && \
+    chmod a+x /usr/local/bin/repo
+
+RUN PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man pipx install kas==5.0


### PR DESCRIPTION
While copying the 24.04 containerfile, I wondered (and still see no reason) why the ca-certificates install should run separately after setting locales env. action-runner container also does install it inline with the other packages.

Did not start a master test build yet... This is just to share what was the result of my short look into the topic yesterday.

Not sure if we need to update kas to i.e. 5.2 ...